### PR TITLE
feat: use the `TranslationParams` type to infer translation params

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -97,6 +97,10 @@ export {
   InferParamTypeFromFieldType,
   /** @deprecated Use {@link InferParamTypeFromFieldType} */ InferParamTypeFromFieldType as ParamTypeInferredFromFieldType,
 } from "./src/types/InferParamTypeFromFieldType";
+export {
+  TranslationHasParams,
+  TranslationParams,
+} from "./src/types/InferTranslationParams";
 
 // XAPI
 export { XAPIDefinition } from "./src/types/XAPIDefinition";

--- a/src/types/InferTranslationParams.ts
+++ b/src/types/InferTranslationParams.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
+import type { Join, Split } from "type-fest";
+import type { Prettify } from "../utility-types";
+
+type StartsWith<
+  TString extends string,
+  TPrefix extends string,
+> = TString extends `${TPrefix}${string}` ? true : false;
+
+// TODO: Split by punctuation (".", ",", ";", ":") and line breaks as well
+type SplitWords<TString extends string> = Split<TString, " ">;
+
+export type TranslationHasParams<TTranslation extends string> =
+  TTranslation extends `${string}:${string}` ? true : false;
+
+export type TranslationParams<
+  TTranslation extends string,
+  TWords extends Array<string> = SplitWords<TTranslation>,
+> = Prettify<
+  TWords extends [infer TFirstWord, ...infer TRestWords]
+    ? TFirstWord extends string
+      ? StartsWith<TFirstWord, ":"> extends true
+        ? TFirstWord extends ":"
+          ? TRestWords extends []
+            ? {}
+            : TRestWords extends Array<string>
+            ? TranslationParams<Join<TRestWords, " ">>
+            : {}
+          : Record<TFirstWord, string> &
+              (TRestWords extends []
+                ? {}
+                : TRestWords extends Array<string>
+                ? TranslationParams<Join<TRestWords, " ">>
+                : {})
+        : TRestWords extends string[]
+        ? TRestWords extends []
+          ? {}
+          : TRestWords extends Array<string>
+          ? TranslationParams<Join<TRestWords, " ">>
+          : {}
+        : {}
+      : {}
+    : {}
+>;
+
+// eslint-disable-next-line @typescript-eslint/ban-types

--- a/src/types/InferTranslationParams.ts
+++ b/src/types/InferTranslationParams.ts
@@ -33,12 +33,10 @@ export type TranslationParams<
                 : TRestWords extends Array<string>
                 ? TranslationParams<Join<TRestWords, " ">>
                 : {})
-        : TRestWords extends string[]
-        ? TRestWords extends []
-          ? {}
-          : TRestWords extends Array<string>
-          ? TranslationParams<Join<TRestWords, " ">>
-          : {}
+        : TRestWords extends []
+        ? {}
+        : TRestWords extends Array<string>
+        ? TranslationParams<Join<TRestWords, " ">>
         : {}
       : {}
     : {}

--- a/src/types/InferTranslationParams.ts
+++ b/src/types/InferTranslationParams.ts
@@ -43,5 +43,3 @@ export type TranslationParams<
       : {}
     : {}
 >;
-
-// eslint-disable-next-line @typescript-eslint/ban-types

--- a/test/InferTranslationParams.test.ts
+++ b/test/InferTranslationParams.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-ts-comment, @typescript-eslint/no-namespace */
+
+import type { AreEqual, Expect } from "../src/test-utility-types";
+import type {
+  TranslationHasParams,
+  TranslationParams,
+} from "../src/types/InferTranslationParams";
+
+// @ts-ignore Test
+namespace Test_InferParams_One {
+  type Expected = {
+    ":count": string;
+  };
+
+  type Actual = TranslationParams<":count cats">;
+
+  // @ts-ignore Test
+  type Test =
+    // prettier-ignore
+    Expect<AreEqual<Actual, Expected>>;
+}
+
+// @ts-ignore Test
+namespace Test_InferParams_Multiple {
+  type Expected = {
+    ":count": string;
+    ":animal": string;
+    ":zoo-name": string;
+  };
+
+  type Actual = TranslationParams<"We have :count :animal in :zoo-name">;
+  // type Actual = TranslationParams<"We have :count :animal in :zoo-name.">;
+
+  // @ts-ignore Test
+  type Test =
+    // prettier-ignore
+    Expect<AreEqual<Actual, Expected>>;
+}
+
+// @ts-ignore Test
+namespace Test_HasParams_True {
+  type Expected = true;
+
+  type Actual = TranslationHasParams<":count cat">;
+
+  // @ts-ignore Test
+  type Test =
+    // prettier-ignore
+    Expect<AreEqual<Actual, Expected>>;
+}
+
+// @ts-ignore Test
+namespace Test_HasParams_True {
+  type Expected = true;
+
+  type Actual = TranslationHasParams<"Our :count cats">;
+
+  // @ts-ignore Test
+  type Test =
+    // prettier-ignore
+    Expect<AreEqual<Actual, Expected>>;
+}
+
+// @ts-ignore Test
+namespace Test_HasParams_False {
+  type Expected = false;
+
+  type Actual = TranslationHasParams<"cat">;
+
+  // @ts-ignore Test
+  type Test =
+    // prettier-ignore
+    Expect<AreEqual<Actual, Expected>>;
+}


### PR DESCRIPTION
A string part is considered a parameter if it starts with `:` and ends with ` ` or is at the end of the string.

It does not yet support splitting by punctuation (`.`, `,`, `;` and `:`) or by line breaks.