### PR TITLE
feat(h5p-types): remove deprecated type aliases

### DIFF
--- a/packages/h5p-types/index.d.ts
+++ b/packages/h5p-types/index.d.ts
@@ -1,15 +1,9 @@
 // Structs
-export {
-  /** @deprecated Use {@link H5PAudio} */ H5PAudio as Audio,
-  H5PAudio,
-} from "./src/types/H5PAudio";
+export { H5PAudio } from "./src/types/H5PAudio";
 export { H5PBehaviour } from "./src/types/H5PBehaviour";
 export { H5PCCVersions } from "./src/types/H5PCCVersions";
 export { H5PContentId } from "./src/types/H5PContentId";
-export {
-  /** @deprecated Use {@link H5PCopyright} */ H5PCopyright as Copyright,
-  H5PCopyright,
-} from "./src/types/H5PCopyright";
+export { H5PCopyright } from "./src/types/H5PCopyright";
 export { H5PCopyrightLicenses } from "./src/types/H5PCopyrightLicenses";
 export { H5PDisplayOptions } from "./src/types/H5PDisplayOptions";
 export { H5PEnterMode } from "./src/types/H5PEnterMode";
@@ -33,21 +27,12 @@ export { H5PFieldWidgetExtension } from "./src/types/H5PFieldWidgetExtension";
 // export {H5PFont} from "./src/types/H5PFont";
 export { H5PForm } from "./src/types/H5PForm";
 export { H5PGroup } from "./src/types/H5PGroup";
-export {
-  H5PImage,
-  /** @deprecated Use {@link H5PImage} */ H5PImage as Image,
-} from "./src/types/H5PImage";
+export { H5PImage } from "./src/types/H5PImage";
 export { H5PImportance } from "./src/types/H5PImportance";
 export { H5PL10n } from "./src/types/H5PL10n";
-export {
-  H5PLibrary,
-  /** @deprecated Use {@link H5PLibrary} */ H5PLibrary as Library,
-} from "./src/types/H5PLibrary";
+export { H5PLibrary } from "./src/types/H5PLibrary";
 export { H5PLibraryInfo } from "./src/types/H5PLibraryInfo";
-export {
-  H5PMedia,
-  H5PMedia as /** @deprecated Use {@link H5PMedia} */ Media,
-} from "./src/types/H5PMedia";
+export { H5PMedia } from "./src/types/H5PMedia";
 export { H5PMediaCopyright } from "./src/types/H5PMediaCopyright";
 export { H5PMetadata } from "./src/types/H5PMetadata";
 export { H5PMetadataForm } from "./src/types/H5PMetadataForm";
@@ -73,10 +58,7 @@ export { H5PEditorContentType } from "./src/types/H5PEditorContentType";
 export { H5PEvent } from "./src/types/H5PEvent";
 export { H5PFieldClass } from "./src/types/H5PFieldClass";
 export { H5PThumbnail } from "./src/types/H5PThumbnail";
-export {
-  H5PVideo,
-  /** @deprecated Use {@link H5PVideo} */ H5PVideo as Video,
-} from "./src/types/H5PVideo";
+export { H5PVideo } from "./src/types/H5PVideo";
 
 // Enums
 export { H5PFieldType } from "./src/types/H5PFieldType";
@@ -98,10 +80,7 @@ export { IH5PWidget } from "./src/types/Interfaces/IH5PWidget";
 // Infer utils
 export { InferGroupParams } from "./src/types/InferGroupParams";
 export { InferL10nType } from "./src/types/InferL10nType";
-export {
-  InferParamTypeFromFieldType,
-  /** @deprecated Use {@link InferParamTypeFromFieldType} */ InferParamTypeFromFieldType as ParamTypeInferredFromFieldType,
-} from "./src/types/InferParamTypeFromFieldType";
+export { InferParamTypeFromFieldType } from "./src/types/InferParamTypeFromFieldType";
 export { InferParamsFromSemantics } from "./src/types/InferParamsFromSemantics";
 export {
   TranslationHasParams,

--- a/packages/h5p-utils/src/models/H5PWidget.ts
+++ b/packages/h5p-utils/src/models/H5PWidget.ts
@@ -3,13 +3,13 @@ import type {
   H5PForm,
   H5PSetValue,
   IH5PWidget,
-  ParamTypeInferredFromFieldType,
+  InferParamTypeFromFieldType,
 } from "h5p-types";
 import { H5P } from "../utils/H5P.utils.js";
 
 export abstract class H5PWidget<
     TField extends H5PField = H5PField,
-    TParams = ParamTypeInferredFromFieldType<TField>,
+    TParams = InferParamTypeFromFieldType<TField>,
   >
   extends H5P.EventDispatcher
   implements IH5PWidget


### PR DESCRIPTION
## 📝 Description

These can all be drop-in replaced:

- `Audio` -> `H5PAudio`
- `Copyright` -> `H5PCopyright`
- `Image` -> `H5PImage`
- `Library` -> `H5PLibrary` 
- `Media` -> `H5PMedia`
- `Video` -> `H5PVideo`
- `ParamTypeInferredFromFieldType` -> `InferParamTypeFromFieldType`

