### PR TITLE
refactor: change H5PObject and H5PEditorObject's function properties to methods

### DIFF
--- a/packages/h5p-types/src/types/H5PEditorObject.ts
+++ b/packages/h5p-types/src/types/H5PEditorObject.ts
@@ -15,10 +15,7 @@ import type { IH5PWidget } from "./Interfaces/IH5PWidget";
  *
  * @see https://h5p.org/node/2468
  */
-export type H5PEditorObject<
-  TWidgetMachineName extends string = never,
-  TWidgetName extends string = never,
-> = {
+export interface H5PEditorObject extends Record<string, unknown> {
   // --- Properties ---
   constants: {
     otherLibraries: string;
@@ -43,7 +40,7 @@ export type H5PEditorObject<
 
   supportedLanguages: Record<string, string>;
 
-  widgets: Record<string, unknown> & Record<TWidgetName, unknown>;
+  widgets: Record<string, unknown>;
 
   // --- Methods ---
   /**
@@ -55,32 +52,32 @@ export type H5PEditorObject<
    * @param ancestor
    * @param skipAppendTo Skips appending the common field if set
    */
-  addCommonField: <TField extends H5PField>(
+  addCommonField<TField extends H5PField>(
     field: TField,
     parent: H5PForm,
     params: InferParamTypeFromFieldType<TField>,
     ancestor: H5PForm,
     skipAppendTo?: boolean,
-  ) => void;
+  ): void;
 
   /**
    * Bind events to important description
    */
-  bindImportantDescriptionEvents: (
+  bindImportantDescriptionEvents(
     widget: IH5PWidget,
     fieldName: string,
     parent: H5PForm,
-  ) => void;
+  ): void;
 
   /**
    * Check if clipboard can be pasted
    */
-  canPaste: (
+  canPaste(
     clipboard: {
       generic?: unknown;
     } & Record<string, unknown>,
     libs: Record<string, unknown>,
-  ) => boolean;
+  ): boolean;
 
   /**
    * Check if clipboard can be pasted and give reason if not.
@@ -89,12 +86,12 @@ export type H5PEditorObject<
    * @param libs Libraries to compare against.
    * @return Results. {canPaste: boolean, reason: string, description: string}.
    */
-  canPastePlus: (
+  canPastePlus(
     clipboard: {
       generic?: unknown;
     } & Record<string, unknown>,
     libs: Record<string, unknown>,
-  ) =>
+  ):
     | { canPaste: true }
     | {
         canPaste: false;
@@ -109,18 +106,18 @@ export type H5PEditorObject<
    * @param $input
    * @param value
    */
-  checkErrors: <
+  checkErrors<
     TValue extends string | boolean | number | Record<string, unknown>,
   >(
     $errors: JQuery,
     $input: JQuery,
     value: TValue,
-  ) => TValue | false;
+  ): TValue | false;
 
   /**
    * Confirm replace if there is content selected
    */
-  confirmReplace: (library: string, top: number, next: () => void) => void;
+  confirmReplace(library: string, top: number, next: () => void): void;
 
   /**
    * Create HTML wrapper for a boolean field item.
@@ -129,11 +126,11 @@ export type H5PEditorObject<
    * @param content
    * @param inputId
    */
-  createBooleanFieldMarkup: (
+  createBooleanFieldMarkup(
     field: H5PField,
     content: string,
     inputId?: string,
-  ) => string;
+  ): string;
 
   /**
    * Makes it easier to add consistent buttons across the editor widget
@@ -143,22 +140,22 @@ export type H5PEditorObject<
    * @param handler Action handler when triggered
    * @param displayTitle Show button with text. Default: `false`
    */
-  createButton: (
+  createButton(
     id: string,
     title: string,
     handler: () => void,
     displayTitle?: boolean,
-  ) => JQuery<HTMLDivElement>;
+  ): JQuery<HTMLDivElement>;
 
   /**
    * Generate markup for the copy and paste buttons
    */
-  createCopyPasteButtons: () => string;
+  createCopyPasteButtons(): string;
 
   /**
    * Create a description
    */
-  createDescription: (description: string, inputId?: string) => string;
+  createDescription(description: string, inputId?: string): string;
 
   /**
    * Create an error paragraph with the given message
@@ -167,7 +164,7 @@ export type H5PEditorObject<
    *
    * @returns Message wrapped in <p>-tags
    */
-  createError: (message: string) => string;
+  createError(message: string): string;
 
   /**
    * Create HTML wrapper for a field item.
@@ -179,18 +176,14 @@ export type H5PEditorObject<
    * @param content
    * @param inputId
    */
-  createFieldMarkup: (
-    field: H5PField,
-    content: string,
-    inputId?: string,
-  ) => string;
+  createFieldMarkup(field: H5PField, content: string, inputId?: string): string;
 
   /**
    * Create an important description
    */
-  createImportantDescription: (
+  createImportantDescription(
     importantDescription: H5PFieldText["important"],
-  ) => string;
+  ): string;
 
   /**
    * Create the HTML wrapper for field items.
@@ -202,12 +195,12 @@ export type H5PEditorObject<
    * @param description  Optional description text for the field. If set, it will be included beneath the field edit form
    * @param content HTML content for the field as a string. Inserted in the wrapper
    */
-  createItem: (
+  createItem(
     type: H5PField["type"],
     label: string | undefined,
     description: string | undefined,
     content: string,
-  ) => string;
+  ): string;
 
   /**
    * Create a label to wrap content in.
@@ -217,7 +210,7 @@ export type H5PEditorObject<
    *
    * @returns Label as string of HTML
    */
-  createLabel: (field: H5PField, content?: string) => string;
+  createLabel(field: H5PField, content?: string): string;
 
   /**
    * Create HTML for select options.
@@ -228,11 +221,11 @@ export type H5PEditorObject<
    *
    * @returns Option as string of HTML
    */
-  createOption: (value: string, text: string, selected?: boolean) => string;
+  createOption(value: string, text: string, selected?: boolean): string;
 
-  createImportance: <TImportance extends H5PImportance | undefined | null>(
+  createImportance<TImportance extends H5PImportance | undefined | null>(
     importance: H5PImportance | undefined | null,
-  ) => TImportance extends H5PImportance ? `importance-${TImportance}` : "";
+  ): TImportance extends H5PImportance ? `importance-${TImportance}` : "";
 
   /**
    *
@@ -244,13 +237,13 @@ export type H5PEditorObject<
    *
    * @returns Input field as string of HTML
    */
-  createText: (
+  createText(
     value?: string,
     maxLength?: number,
     placeholder?: string,
     id?: string,
     describedby?: string,
-  ) => string;
+  ): string;
 
   /**
    * Check if the current library is entitled for the metadata button. True by default.
@@ -258,14 +251,14 @@ export type H5PEditorObject<
    * @param library - Current library.
    * @return True, if form should have the metadata button.
    */
-  enableMetadata: (library: string) => boolean;
+  enableMetadata(library: string): boolean;
 
   /**
    * Find the nearest ancestor which handles `commonFields`.
    *
    * @param parent
    */
-  findAncestor: (parent: H5PForm) => H5PForm | undefined;
+  findAncestor(parent: H5PForm): H5PForm | undefined;
 
   /**
    * Find field from a path
@@ -273,20 +266,20 @@ export type H5PEditorObject<
    * @param path
    * @param parent
    */
-  findField: <
+  findField<
     TField extends H5PForm = IH5PFieldInstance,
     TParent extends H5PForm = H5PForm,
   >(
     path: string | Array<string>,
     parent: TParent,
-  ) => TField | false;
+  ): TField | false;
 
   /**
    * Find the nearest library ancestor. Used when adding common fields.
    *
    * @param parent
    */
-  findLibraryAncestor: (parent: H5PForm) => H5PForm | undefined;
+  findLibraryAncestor(parent: H5PForm): H5PForm | undefined;
 
   /**
    * Search for a field or a set of fields. Returns `null` if the field isn't found.
@@ -294,10 +287,10 @@ export type H5PEditorObject<
    * @param fieldName
    * @param semanticsStructure
    */
-  findSemanticsField: (
+  findSemanticsField(
     fieldName: string,
     semanticsStructure: H5PField | Array<H5PField>,
-  ) => H5PField | Array<H5PField> | null;
+  ): H5PField | Array<H5PField> | null;
 
   /**
    * Observe a field to get changes to its params.This is used to track changes
@@ -318,28 +311,28 @@ export type H5PEditorObject<
    * @param path Relative to the parent object
    * @param callback Gets called for params changes
    */
-  followField: <TField extends H5PField = H5PField>(
+  followField<TField extends H5PField = H5PField>(
     parent: H5PForm,
     path: string,
     callback: (params: InferParamTypeFromFieldType<TField>) => void,
-  ) => void;
+  ): void;
 
   /**
    * Helps generating a consistent description ID across fields
    */
-  getDescriptionId: (id: string) => string;
+  getDescriptionId(id: string): string;
 
   /**
    * Generates a consistent and unique field ID for the given field
    */
-  getNextFieldId: (field: H5PField) => string;
+  getNextFieldId(field: H5PField): string;
 
   /**
    * Recursively traverse parents to find the library our field belongs to
    *
    * @param parent
    */
-  getParentLibrary: (parent: H5PForm) => H5PForm | null;
+  getParentLibrary(parent: H5PForm): H5PForm | null;
 
   /**
    * Alternate the background color of fields
@@ -347,12 +340,12 @@ export type H5PEditorObject<
    * @param parent
    * @returns `odd` or `even` to determine background color of callee
    */
-  getParentZebra: (parent: H5PForm) => H5PForm["zebra"];
+  getParentZebra(parent: H5PForm): H5PForm["zebra"];
 
   /**
    * Helper function for detecting field widget
    */
-  getWidgetName: (field: H5PField) => string;
+  getWidgetName(field: H5PField): string;
 
   /**
    * Mimics a simple version of PHP htmlspecialchars. Basically replaces brackets
@@ -367,7 +360,7 @@ export type H5PEditorObject<
    * // &lt;h1&gt;&quot;Hello world&quot;&lt;/h1&gt;
    * ```
    */
-  htmlspecialchars: (escapedHtml: string) => string;
+  htmlspecialchars(escapedHtml: string): string;
 
   /**
    * Joins an array of strings if they are defined and non empty
@@ -375,21 +368,21 @@ export type H5PEditorObject<
    * @param arr
    * @param separator Default: `" "`
    */
-  joinNonEmptyStrings: (
+  joinNonEmptyStrings(
     strings: Array<string | undefined>,
     separator?: string,
-  ) => string;
+  ): string;
 
   /**
    * @deprecated Use `H5P.libraryFromString` instead
    */
-  libraryFromString: <
+  libraryFromString<
     TLibraryName extends string,
     TMajorVersion extends number,
     TMinorVersion extends number,
   >(
     library: `${TLibraryName} ${TMajorVersion}.${TMinorVersion}`,
-  ) =>
+  ):
     | {
         machineName: TLibraryName;
         majorVersion: TMajorVersion;
@@ -406,29 +399,29 @@ export type H5PEditorObject<
    * @param libraryName On the form "machineName majorVersion.minorVersion"
    * @param callback
    */
-  libraryRequested: <TSemantics = unknown>(
+  libraryRequested<TSemantics = unknown>(
     libraryName: `${string} ${number}.${number}`,
     callback: (semantics: TSemantics) => void,
-  ) => void;
+  ): void;
 
   /**
    * Translates a library object to a library string.
    *
    * @param library Library object with machineName, majorVersion and minorVersion set
    */
-  libraryToString: <
+  libraryToString<
     TLib extends Pick<
       H5PLibrary,
       "machineName" | "majorVersion" | "minorVersion"
     >,
   >(
     library: TLib,
-  ) => `${TLib["machineName"]} ${TLib["majorVersion"]}.${TLib["minorVersion"]}`;
+  ): `${TLib["machineName"]} ${TLib["majorVersion"]}.${TLib["minorVersion"]}`;
 
   /**
    * Help load JavaScripts, prevents double loading
    */
-  loadJs: (src: string, doneCallback: () => void) => void;
+  loadJs(src: string, doneCallback: () => void): void;
 
   /**
    * Loads a complete library, with semantics, scripts and CSS from the server.
@@ -437,10 +430,10 @@ export type H5PEditorObject<
    * @param libraryName
    * @param callback Callback that will be called with the library's semantics when loaded
    */
-  loadLibrary: <TSemantics = unknown>(
+  loadLibrary<TSemantics = unknown>(
     libraryName: `${string} ${number}.${number}`,
     callback: (semantics: TSemantics) => void,
-  ) => void;
+  ): void;
 
   /**
    * Recursive processing of the semantics chunks.
@@ -451,7 +444,7 @@ export type H5PEditorObject<
    * @param parent
    * @param machineName Machine name of library that is being processed
    */
-  processSemanticsChunk: <TFields extends Array<H5PField> = Array<H5PField>>(
+  processSemanticsChunk<TFields extends Array<H5PField> = Array<H5PField>>(
     semanticsChunk: TFields,
     params: Record<
       TFields[number]["name"],
@@ -460,14 +453,14 @@ export type H5PEditorObject<
     $wrapper: JQuery<HTMLElement>,
     parent: H5PForm,
     machineName?: string,
-  ) => void;
+  ): void;
 
   /**
    * Call remove on the given children
    *
    * @param children
    */
-  removeChildren: (children: Array<IH5PWidget>) => void;
+  removeChildren(children: Array<IH5PWidget>): void;
 
   /**
    * Render common fields of content type with given machine name.
@@ -475,15 +468,12 @@ export type H5PEditorObject<
    * @param machineName Machine name of content type with common fields
    * @param libraries Library data for machine name
    */
-  renderCommonField: (
-    machineName: string,
-    libraries?: Array<H5PLibrary>,
-  ) => void;
+  renderCommonField(machineName: string, libraries?: Array<H5PLibrary>): void;
 
   /**
    * Reset loaded libraries - i.e removes CSS added previously
    */
-  resetLoadedLibraries: () => void;
+  resetLoadedLibraries(): void;
 
   /**
    * Attach ancestor of parent's common fields to a new wrapper
@@ -491,7 +481,7 @@ export type H5PEditorObject<
    * @param parent Parent content type instance that common fields should be attached to
    * @param wrapper New wrapper of common fields
    */
-  setCommonFieldsWrapper: (parent: H5PForm, wrapper: HTMLElement) => void;
+  setCommonFieldsWrapper(parent: H5PForm, wrapper: HTMLElement): void;
 
   /**
    * Translate text strings
@@ -502,11 +492,11 @@ export type H5PEditorObject<
    *
    * @returns Translated string, or a default text if the translation is missing
    */
-  t: (
-    library: "core" | `H5PEditor.${string}` | `H5PEditor.${TWidgetMachineName}`,
+  t(
+    library: "core" | `H5PEditor.${string}` | string,
     key: string,
     vars?: Record<`:${string}`, string>,
-  ) => string;
+  ): string;
 
   /**
    * Update common fields default values for the given semantics.
@@ -516,11 +506,11 @@ export type H5PEditorObject<
    * @param translation
    * @param parentIsCommon Used to indicated that one of the ancestors is a common field
    */
-  updateCommonFieldsDefault: (
+  updateCommonFieldsDefault(
     semantics: Array<H5PField>,
     translation: Array<H5PField>,
     parentIsCommon?: boolean,
-  ) => void;
+  ): void;
 
   /**
    * Wraps a field with some metadata classes, and adds error field.
@@ -528,10 +518,9 @@ export type H5PEditorObject<
    * @param field
    * @param markup
    */
-  wrapFieldMarkup: (field: H5PField, markup: string) => string;
+  wrapFieldMarkup(field: H5PField, markup: string): string;
 
   // --- Classes ---
   $: typeof jQuery;
   ContentType: H5PEditorContentType;
-} & Record<string, unknown> &
-  Record<`${TWidgetMachineName}`, unknown>;
+}

--- a/packages/h5p-types/src/types/H5PObject.ts
+++ b/packages/h5p-types/src/types/H5PObject.ts
@@ -61,7 +61,7 @@ export interface H5PObject {
    * @param path
    * @param parameter
    */
-  addQueryParameter: (path: string, parameter: string) => string;
+  addQueryParameter(path: string, parameter: string): string;
 
   /**
    * Show a toast message.
@@ -87,7 +87,7 @@ export interface H5PObject {
    * @param config.position.noOverflowY True to prevent overflow top and bottom. Default: `false`
    * @param config.position.overflowReference DOM reference for overflow. Default: `document.body`
    */
-  attachToastTo: (
+  attachToastTo(
     element: HTMLElement,
     message: string,
     config?: {
@@ -107,20 +107,20 @@ export interface H5PObject {
         overflowReference?: HTMLElement;
       };
     },
-  ) => void;
+  ): void;
 
   buildMetadataCopyrights(metadata: H5PMetadata): H5PMediaCopyright;
 
-  classFromName: (name: `H5P.${string}`) => IH5PContentType;
+  classFromName(name: `H5P.${string}`): IH5PContentType;
 
   /**
    * Store item in the H5P Clipboard
    */
-  clipboardify: <
+  clipboardify<
     TParams extends Record<string, unknown> = Record<string, unknown>,
   >(
     clipboardItem: H5PClipboardItem<TParams> | TParams,
-  ) => void;
+  ): void;
 
   /**
    * Recursively clone the given object
@@ -129,7 +129,7 @@ export interface H5PObject {
    * @param recursive
    * @returns A clone of object
    */
-  cloneObject: <T>(object: T, recursive?: boolean) => T;
+  cloneObject<T>(object: T, recursive?: boolean): T;
 
   /**
    * Create title as an HTML string
@@ -137,14 +137,14 @@ export interface H5PObject {
    * @param rawTitle
    * @param maxLength Default: 60
    */
-  createTitle: (rawTitle: string, maxLength?: number) => string;
+  createTitle(rawTitle: string, maxLength?: number): string;
 
-  createUUID: () => string;
+  createUUID(): string;
 
   /**
    * Check if styles path/key is loaded
    */
-  cssLoaded: (path: string) => boolean;
+  cssLoaded(path: string): boolean;
 
   /**
    * @private
@@ -156,15 +156,15 @@ export interface H5PObject {
    * @param dataId Identifies the set of data for this content
    * @param subContentId Identifies which data belongs to sub content
    */
-  deleteUserData: (
+  deleteUserData(
     contentId: H5PContentId,
     dataId: string,
     subContentId?: H5PContentId,
-  ) => void;
+  ): void;
 
-  error: (error: Error | string) => void;
+  error(error: Error | string): void;
 
-  exitFullScreen: () => void;
+  exitFullScreen(): void;
 
   /**
    * Gather a flat list of copyright information from the given parameters.
@@ -177,7 +177,7 @@ export interface H5PObject {
    * @param extras.machineName - Library name of some kind.
    *   Metadata of the content instance.
    */
-  findCopyrights: (
+  findCopyrights(
     info: H5PContentCopyrights,
     parameters:
       | Record<
@@ -198,17 +198,17 @@ export interface H5PObject {
         >,
     contentId: H5PContentId,
     extras?: { metadata: H5PMetadata; machineName: string },
-  ) => void;
+  ): void;
 
-  fullScreen: (
+  fullScreen(
     $element: JQuery,
     instance: IH5PContentType,
-    exitCallback?: () => void,
+    exitCallback: () => void,
     body?: JQuery,
     forceSemiFullScreen?: boolean,
-  ) => void;
+  ): void;
 
-  getClipboard: () =>
+  getClipboard():
     | ({
         generic?: unknown;
       } & Record<string, unknown>)
@@ -220,7 +220,7 @@ export interface H5PObject {
    * @param {number} contentId
    * @return {Object}
    */
-  getContentForInstance: (contentId?: H5PContentId) =>
+  getContentForInstance(contentId?: H5PContentId):
     | {
         contentUserData?: Array<unknown> | undefined;
         displayOptions?: H5PDisplayOptions;
@@ -241,7 +241,7 @@ export interface H5PObject {
   /**
    * @deprecated Use `getPath` instead
    */
-  getContentPath: (contentId: H5PContentId) => string;
+  getContentPath(contentId: H5PContentId): string;
 
   /**
    * Gather copyright information for the given content.
@@ -267,16 +267,15 @@ export interface H5PObject {
    *
    * @returns crossOrigin attribute value required by the source
    */
-  getCrossOrigin:
-    | ((source: string) => string | null)
-    | ((source: H5PMedia) => string | undefined);
+  getCrossOrigin(source: string): string | null;
+  getCrossOrigin(source: H5PMedia): string | undefined;
 
   /**
    * Get config for a library
    *
    * @param string machineName
    */
-  getLibraryConfig: (machineName: string) => unknown | Record<string, never>;
+  getLibraryConfig(machineName: string): unknown | Record<string, never>;
 
   /**
    * Get the path to the library
@@ -284,7 +283,7 @@ export interface H5PObject {
    * @param library The library identifier in the format "machineName-majorVersion.minorVersion".
    * @returns The full path to the library
    */
-  getLibraryPath: (library: `${string}-${number}.${number}`) => string;
+  getLibraryPath(library: `${string}-${number}.${number}`): string;
 
   /**
    * Find the path to the content files based on the id of the content.
@@ -295,7 +294,7 @@ export interface H5PObject {
    *
    * @returns Complete URL to path
    */
-  getPath: (path: string, contentId: H5PContentId) => string;
+  getPath(path: string, contentId: H5PContentId): string;
 
   /**
    * @private
@@ -307,12 +306,12 @@ export interface H5PObject {
    * @param done Callback with error and data parameters
    * @param subContentId Identifies which data belongs to sub content
    */
-  getUserData: (
+  getUserData(
     contentId: H5PContentId,
     dataId: string,
     done: (error?: Error, data?: Record<string, unknown> | null) => void,
     subContentId?: H5PContentId,
-  ) => void;
+  ): void;
 
   /**
    * Initialize H5P content.
@@ -320,7 +319,7 @@ export interface H5PObject {
    *
    * @param target DOM Element
    */
-  init: (target: HTMLElement) => void;
+  init(target: HTMLElement): void;
 
   /**
    * Recursive function that detects deep empty structures.
@@ -344,12 +343,12 @@ export interface H5PObject {
    * H5P.isEmpty({ a: { b: "" } });
    * ```
    */
-  isEmpty: (value: unknown) => boolean;
+  isEmpty(value: unknown): boolean;
 
   /**
    * Check if JavaScript path/key is loaded
    */
-  jsLoaded: (path: string) => boolean;
+  jsLoaded(path: string): boolean;
 
   /**
    * Parse library string into values.
@@ -358,13 +357,13 @@ export interface H5PObject {
    * @returns library as an object with machineName, majorVersion and minorVersion properties,
    *          or false if the library parameter is invalid
    */
-  libraryFromString: <
+  libraryFromString<
     TLibraryName extends string,
     TMajorVersion extends number,
     TMinorVersion extends number,
   >(
     library: `${TLibraryName} ${TMajorVersion}.${TMinorVersion}`,
-  ) =>
+  ):
     | {
         machineName: TLibraryName;
         majorVersion: TMajorVersion;
@@ -383,7 +382,7 @@ export interface H5PObject {
    *
    * @returns Instance
    */
-  newRunnable: <
+  newRunnable<
     TLibraryParam extends H5PNewRunnableLibraryParam,
     TState = unknown,
   >(
@@ -392,17 +391,17 @@ export interface H5PObject {
     $attachTo?: JQuery,
     skipResize?: boolean,
     extras?: H5PExtrasWithState<TState>,
-  ) => IH5PContentType & {
+  ): IH5PContentType & {
     $: typeof jQuery;
     libraryInfo: H5PLibraryInfo;
     subContentId: TLibraryParam["subContentId"];
   };
 
-  on: <TData = unknown>(
+  on<TData = unknown>(
     instance: EventDispatcher,
     eventType: string,
     handler: (event: H5PEvent<TData>) => void,
-  ) => void;
+  ): void;
 
   /**
    * Display a dialog containing the embed code
@@ -412,7 +411,7 @@ export interface H5PObject {
    * @param resizeCode The advanced resize code
    * @param size The content's size
    */
-  openEmbedDialog: (
+  openEmbedDialog(
     $element: JQuery<HTMLElement>,
     embedCode: string,
     resizeCode: string,
@@ -420,12 +419,12 @@ export interface H5PObject {
       width: number;
       height: number;
     },
-  ) => void;
+  ): void;
 
   /**
    * Display a dialog containing the download button and copy button
    */
-  openReuseDialog: (
+  openReuseDialog(
     $element: JQuery<HTMLElement>,
     contentData: {
       displayOptions: H5PDisplayOptions;
@@ -433,7 +432,7 @@ export interface H5PObject {
     library: ConstructorParameters<typeof H5PClipboardItem>[0],
     instance: IH5PContentType,
     contentId: H5PContentId,
-  ) => void;
+  ): void;
 
   /**
    * Enter semi fullscreen for the given H5P instance
@@ -443,21 +442,21 @@ export interface H5PObject {
    * @param exitCallback Callback function called when user exits fullscreen.
    * @param $body For internal use. Gives the body of the iframe.
    */
-  semiFullScreen: (
+  semiFullScreen(
     $element: Parameters<H5PObject["fullScreen"]>[0],
     instance: Parameters<H5PObject["fullScreen"]>[1],
     exitCallback: Parameters<H5PObject["fullScreen"]>[2],
     $body: Parameters<H5PObject["fullScreen"]>[3],
-  ) => void;
+  ): void;
 
   /**
    * Set item in the H5P Clipboard
    *
    * @param clipboardItem Data to be set
    */
-  setClipboard: <TParams extends Record<string, unknown>>(
+  setClipboard<TParams extends Record<string, unknown>>(
     clipboardItem: H5PClipboardItem<TParams> | TParams,
-  ) => void;
+  ): void;
 
   /**
    * Post finished results for user
@@ -469,12 +468,12 @@ export interface H5PObject {
    * @param maxScore The maximum score/points that can be achieved
    * @param time Reported time consumption/usage
    */
-  setFinished: (
+  setFinished(
     contentId: H5PContentId,
     score: number,
     maxScore: number,
     time?: number,
-  ) => void;
+  ): void;
 
   /**
    * Helper for setting the crossOrigin attribute + the complete correct source.
@@ -484,11 +483,11 @@ export interface H5PObject {
    * @param source File object from parameters/json_content (created by H5PEditor)
    * @param contentId Needed to determine the complete correct file path
    */
-  setSource: (
+  setSource(
     element: HTMLImageElement | HTMLVideoElement | HTMLAudioElement,
     source: H5PMedia,
     contentId: H5PContentId,
-  ) => void;
+  ): void;
 
   /**
    * @private
@@ -505,7 +504,7 @@ export interface H5PObject {
    * @param extras.errorCallback Callback with error as parameters
    * @param extras.async Default: `true`
    */
-  setUserData: (
+  setUserData(
     contentId: H5PContentId,
     dataId: string,
     data: unknown,
@@ -513,17 +512,17 @@ export interface H5PObject {
       subContentId?: H5PContentId;
       preloaded?: boolean;
       deleteOnChange?: boolean;
-      errorCallback?: (error: Error) => void;
+      errorCallback(error: Error): void;
       async?: boolean;
     },
-  ) => void;
+  ): void;
 
   /**
    * Shuffle an array in place
    *
    * @deprecated Use [Array#sort](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) instead
    */
-  shuffleArray: <T>(array: Array<T>) => Array<T>;
+  shuffleArray<T>(array: Array<T>): Array<T>;
 
   /**
    * Translate text strings.
@@ -535,11 +534,11 @@ export interface H5PObject {
    *
    * @returns Translated text
    */
-  t: (
+  t(
     key: string,
     placeholderVars?: Record<string, string>,
     namespace?: string,
-  ) => string;
+  ): string;
 
   /**
    * Trigger an event on an instance
@@ -551,19 +550,19 @@ export interface H5PObject {
    * @param data
    * @param extras
    */
-  trigger: <TData = unknown>(
+  trigger<TData = unknown>(
     instance: EventDispatcher,
     eventType: Parameters<EventDispatcher["trigger"]>[0],
     data: TData,
     extras: Parameters<EventDispatcher["trigger"]>[2],
-  ) => void;
+  ): void;
 
   /**
    * Remove all empty spaces before and after the value
    *
    * @deprecated Use [`String#trim`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim) instead
    */
-  trim: (value: string) => string;
+  trim(value: string): string;
 
   // --- Classes ---
   jQuery: typeof jQuery;


### PR DESCRIPTION
## 📝 Description

<!--
Please provide a brief description of the purpose and context of this
pull request. What problem does it address or what feature does it
introduce? This will help reviewers understand the changes at a high
level. Include any relevant background information or references to
issues/feature requests.
-->

By changing the properties from arrow functions to methods, the generated documentation will make much more sense. Perhaps we should update the methods to be static some time in the future.
