### PR TITLE
fix(h5p-types): Make exitCallback of fullscreen optional

### DIFF
--- a/packages/h5p-types/src/types/H5PObject.ts
+++ b/packages/h5p-types/src/types/H5PObject.ts
@@ -301,7 +301,7 @@ export interface H5PObject {
   fullScreen(
     $element: JQuery,
     instance: IH5PContentType,
-    exitCallback: () => void,
+    exitCallback?: () => void,
     body?: JQuery,
     forceSemiFullScreen?: boolean,
   ): void;


### PR DESCRIPTION
## 📝 Description
When merged in, will make the `exitCallback` argument of `H5P.fullScreen` optional, because it is not required.

## 👀 Reviewer's Guide

<!--
Outline the key points that reviewers should focus on when examining this
pull request. This could include specific changes made, potential impact
on existing code, and any relevant testing or usage scenarios.
Providing clear guidance will ensure efficient and effective reviews.
-->

## ✅ Checklist

- [ ] **Pull Request Title and Description**: Is the pull request title concise and descriptive? Does the description provide enough context for reviewers to understand your changes?
- [x] **Review**: Have you gone through your own code changes to catch any potential issues before submitting for review?
- [ ] **Testing**: Have you added appropriate tests to cover the changes you've made? Are existing tests passing?
