### PR TITLE
docs: add example showing how to build content types with Vite

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -25,6 +25,7 @@ jobs:
         project:
           - h5p-content-type
           - h5p-content-type-react
+          - h5p-content-type-vite
           - h5p-resumable-content-type
           - h5p-widget
 

--- a/examples/h5p-content-type-vite/.eslintignore
+++ b/examples/h5p-content-type-vite/.eslintignore
@@ -1,0 +1,2 @@
+.turbo
+dist

--- a/examples/h5p-content-type-vite/README.md
+++ b/examples/h5p-content-type-vite/README.md
@@ -1,0 +1,21 @@
+# H5P Content Type with Vite
+
+This is a boilerplate for creating H5P content types with [Vite](https://vitejs.dev/).
+The code is the same as in the [template that uses webpack](../h5p-content-type/), but the build process is different.
+
+## Key differences from webpack
+
+The code in the projects is the same, but not representative for all projects.
+Still, these numbers tell a story about the differences between webpack and Vite.
+
+| Tool    | Compile time |  Output size |
+| ------- | ------------ | ------------ |
+| webpack | ~4s          | 2.69 kB      |
+| Vite    | ~80ms        | ~1.12 kB     |
+
+Vite is generally _much_ quicker and will output a smaller bundle, and its config is by some regarded as simpler.
+
+## Drawbacks
+
+If you decide to go with Vite in a TypeScript project, remember to check types manually, as Vite (and esbuild) does not do this for you to save time when compiling.
+This can be done by running `tsc --noEmit`.

--- a/examples/h5p-content-type-vite/h5p-extensions.d.ts
+++ b/examples/h5p-content-type-vite/h5p-extensions.d.ts
@@ -1,0 +1,1 @@
+import "h5p-types-joubel-ui";

--- a/examples/h5p-content-type-vite/library.json
+++ b/examples/h5p-content-type-vite/library.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://h5p-json-schemas.vercel.app/library.schema.json",
+  "title": "Content Type Vite",
+  "machineName": "H5P.ContentTypeVite",
+  "majorVersion": 1,
+  "minorVersion": 0,
+  "patchVersion": 0,
+  "runnable": 1,
+  "license": "MIT",
+  "author": "",
+  "embedTypes": ["iframe"],
+  "preloadedDependencies": [
+    {
+      "machineName": "H5P.JoubelUI",
+      "majorVersion": 1,
+      "minorVersion": 3
+    }
+  ],
+  "preloadedJs": [
+    {
+      "path": "dist/h5p-content-type-vite.js"
+    }
+  ]
+}

--- a/examples/h5p-content-type-vite/library.json.d.ts
+++ b/examples/h5p-content-type-vite/library.json.d.ts
@@ -1,0 +1,40 @@
+export const $schema : "https://h5p-json-schemas.vercel.app/library.schema.json";
+export const title : "Content Type Vite";
+export const machineName : "H5P.ContentTypeVite";
+export const majorVersion : 1;
+export const minorVersion : 0;
+export const patchVersion : 0;
+export const runnable : 1;
+export const license : "MIT";
+export const author : "";
+export const embedTypes : [
+	"iframe"
+];
+export const preloadedDependencies : [
+	{
+		machineName: "H5P.JoubelUI",
+		majorVersion: 1,
+		minorVersion: 3
+	}
+];
+export const preloadedJs : [
+	{
+		path: "dist/h5p-content-type-vite.js"
+	}
+];
+declare const $defaultExport: {
+	$schema: typeof $schema,
+	title: typeof title,
+	machineName: typeof machineName,
+	majorVersion: typeof majorVersion,
+	minorVersion: typeof minorVersion,
+	patchVersion: typeof patchVersion,
+	runnable: typeof runnable,
+	license: typeof license,
+	author: typeof author,
+	embedTypes: typeof embedTypes,
+	preloadedDependencies: typeof preloadedDependencies,
+	preloadedJs: typeof preloadedJs
+};
+
+export default $defaultExport;

--- a/examples/h5p-content-type-vite/package.json
+++ b/examples/h5p-content-type-vite/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "h5p-content-type-vite",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "watch": "vite",
+    "build": "vite build",
+    "lint:check": "eslint .",
+    "lint:fix": "npm run lint:check -- --fix"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "h5p-utils": "*"
+  },
+  "devDependencies": {
+    "eslint-config-base": "*",
+    "h5p-types": "*",
+    "h5p-types-joubel-ui": "*",
+    "tsconfig-base": "*",
+    "typescript": "5.0",
+    "unplugin-json-dts": "^1.2.0"
+  },
+  "eslintConfig": {
+    "extends": "base"
+  }
+}

--- a/examples/h5p-content-type-vite/semantics.json
+++ b/examples/h5p-content-type-vite/semantics.json
@@ -1,0 +1,616 @@
+[
+  {
+    "label": "Task description",
+    "name": "description",
+    "description": "A guide telling the user how to answer this task.",
+    "type": "text",
+    "optional": true
+  },
+  {
+    "label": "Source language",
+    "name": "sourceLanguage",
+    "description": "Choose the language of the source words.",
+    "type": "select",
+    "options": [
+      { "value": "en", "label": "English" },
+      { "value": "fr", "label": "French" },
+      { "value": "de", "label": "German" },
+      { "value": "nb", "label": "Norwegian bokmål" },
+      { "value": "nn", "label": "Norwegian nynorsk" },
+      { "value": "es", "label": "Spanish" }
+    ],
+    "default": "en"
+  },
+  {
+    "label": "Target language",
+    "name": "targetLanguage",
+    "description": "Choose the language of the target words.",
+    "type": "select",
+    "options": [
+      { "value": "en", "label": "English" },
+      { "value": "fr", "label": "French" },
+      { "value": "de", "label": "German" },
+      { "value": "nb", "label": "Norwegian bokmål" },
+      { "value": "nn", "label": "Norwegian nynorsk" },
+      { "value": "es", "label": "Spanish" }
+    ],
+    "default": "nb"
+  },
+  {
+    "label": "Words",
+    "name": "words",
+    "type": "text",
+    "optional": true,
+    "widget": "csv-to-text",
+    "description": "Add words by uploading a CSV-file or write them in the text field.",
+    "important": {
+      "description": "<ul><li>Source and target words are separated with a comma (,).</li><li>Alternative answers are separated with a forward slash (/).</li><li>You may add a textual tip, using a colon (:) in front of the tip.</li></ul>",
+      "example": "water/sea:w___r,vann/hav:v__n"
+    }
+  },
+  {
+    "name": "overallFeedback",
+    "type": "group",
+    "label": "Overall Feedback",
+    "importance": "low",
+    "expanded": true,
+    "fields": [
+      {
+        "name": "overallFeedback",
+        "type": "list",
+        "widgets": [
+          {
+            "name": "RangeList",
+            "label": "Default"
+          }
+        ],
+        "importance": "high",
+        "label": "Define custom feedback for any score range",
+        "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+        "entity": "range",
+        "min": 1,
+        "defaultNum": 1,
+        "optional": true,
+        "field": {
+          "label": "Overall Feedback",
+          "name": "overallFeedback",
+          "type": "group",
+          "importance": "low",
+          "fields": [
+            {
+              "name": "from",
+              "type": "number",
+              "label": "Score Range",
+              "min": 0,
+              "max": 100,
+              "default": 0,
+              "unit": "%"
+            },
+            {
+              "name": "to",
+              "type": "number",
+              "min": 0,
+              "max": 100,
+              "default": 100,
+              "unit": "%"
+            },
+            {
+              "name": "feedback",
+              "type": "text",
+              "label": "Feedback for defined score range",
+              "importance": "low",
+              "placeholder": "Fill in the feedback",
+              "optional": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "label": "Localization",
+    "name": "l10n",
+    "type": "group",
+    "importance": "low",
+    "common": true,
+    "fields": [
+      {
+        "label": "No valid words",
+        "name": "noValidWords",
+        "default": "No valid words found. Please check your words and try again.",
+        "type": "text"
+      },
+      {
+        "label": "Label for \"Fill in\" answer mode",
+        "name": "fillInLabel",
+        "default": "Fill in",
+        "type": "text"
+      },
+      {
+        "label": "Label for \"Drag text\" answer mode",
+        "name": "dragTextLabel",
+        "default": "Drag text",
+        "type": "text"
+      },
+      {
+        "label": "Answer mode label",
+        "name": "answerModeLabel",
+        "default": "Change answer mode",
+        "type": "text"
+      },
+      {
+        "label": "Language mode label",
+        "name": "languageModeLabel",
+        "default": "Swap languages",
+        "type": "text"
+      },
+      {
+        "label": "Changed answer mode aria",
+        "name": "changedAnswerModeAria",
+        "default": "Changed answer mode to @option",
+        "type": "text"
+      },
+      {
+        "label": "Language mode aria",
+        "name": "languageModeAria",
+        "default": "Swap language from @sourceLanguage to @targetLanguage",
+        "type": "text"
+      },
+      {
+        "label": "Changed language mode aria",
+        "name": "changedLanguageModeAria",
+        "default": "Swapped language from @sourceLanguage to @targetLanguage",
+        "type": "text"
+      },
+      {
+        "label": "Text for \"Next\" button",
+        "name": "next",
+        "default": "Next",
+        "type": "text"
+      },
+      {
+        "label": "Text for \"Finish\" button",
+        "name": "finish",
+        "default": "Finish",
+        "type": "text"
+      },
+      {
+        "label": "Text for \"Restart\" button",
+        "name": "restart",
+        "default": "Restart",
+        "type": "text"
+      },
+      {
+        "label": "Score label",
+        "name": "scoreLabel",
+        "default": "Score",
+        "type": "text"
+      },
+      {
+        "label": "Textual representation of the score bar for those using a readspeaker",
+        "name": "scoreBarLabel",
+        "default": "You got @score out of @maxScore points",
+        "type": "text"
+      },
+      {
+        "label": "Textual representation of the page numbers for those using a readspeaker",
+        "name": "pageNumberLabel",
+        "default": "Page @page of @totalPages",
+        "type": "text"
+      },
+      {
+        "label": "Feedback text",
+        "name": "feedbackText",
+        "default": "Your total score",
+        "type": "text"
+      },
+      {
+        "label": "English",
+        "name": "lang_en",
+        "default": "English",
+        "type": "text"
+      },
+      {
+        "label": "French",
+        "name": "lang_fr",
+        "default": "French",
+        "type": "text"
+      },
+      {
+        "label": "German",
+        "name": "lang_de",
+        "default": "German",
+        "type": "text"
+      },
+      {
+        "label": "Norwegian bokmål",
+        "name": "lang_nb",
+        "default": "Norwegian bokmål",
+        "type": "text"
+      },
+      {
+        "label": "Norwegian nynorsk",
+        "name": "lang_nn",
+        "default": "Norwegian nynorsk",
+        "type": "text"
+      },
+      {
+        "label": "Spanish",
+        "name": "lang_es",
+        "default": "Spanish",
+        "type": "text"
+      }
+    ]
+  },
+  {
+    "label": "Localization for Blanks",
+    "name": "blanksl10n",
+    "importance": "low",
+    "type": "group",
+    "common": true,
+    "fields": [
+      {
+        "label": "Text for \"Show solutions\" button",
+        "name": "showSolutions",
+        "type": "text",
+        "default": "Show solution"
+      },
+      {
+        "label": "Text for \"Retry\" button",
+        "name": "tryAgain",
+        "type": "text",
+        "default": "Retry",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Check\" button",
+        "name": "checkAnswer",
+        "type": "text",
+        "default": "Check",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Submit\" button",
+        "name": "submitAnswer",
+        "type": "text",
+        "default": "Submit",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Not filled out\" message",
+        "name": "notFilledOut",
+        "type": "text",
+        "default": "Please fill in all blanks to view solution",
+        "optional": true
+      },
+      {
+        "label": "Text for \"':ans' is correct\" message",
+        "name": "answerIsCorrect",
+        "type": "text",
+        "default": "':ans' is correct",
+        "optional": true
+      },
+      {
+        "label": "Text for \"':ans' is wrong\" message",
+        "name": "answerIsWrong",
+        "type": "text",
+        "default": "':ans' is wrong",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Answered correctly\" message",
+        "name": "answeredCorrectly",
+        "type": "text",
+        "default": "Answered correctly",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Answered incorrectly\" message",
+        "name": "answeredIncorrectly",
+        "type": "text",
+        "default": "Answered incorrectly",
+        "optional": true
+      },
+      {
+        "label": "Assistive technology label for solution",
+        "name": "solutionLabel",
+        "type": "text",
+        "default": "Correct answer:",
+        "optional": true
+      },
+      {
+        "label": "Assistive technology label for input field",
+        "name": "inputLabel",
+        "type": "text",
+        "description": "Use @num and @total to replace current cloze number and total cloze number.",
+        "default": "Blank input @num of @total",
+        "optional": true
+      },
+      {
+        "label": "Assistive technology label for saying an input has a tip tied to it",
+        "name": "inputHasTipLabel",
+        "type": "text",
+        "default": "Tip available",
+        "optional": true
+      },
+      {
+        "label": "Tip icon label",
+        "name": "tipLabel",
+        "type": "text",
+        "default": "Tip",
+        "optional": true
+      },
+      {
+        "name": "scoreBarLabel",
+        "type": "text",
+        "label": "Textual representation of the score bar for those using a readspeaker",
+        "default": "You got :num out of :total points"
+      },
+      {
+        "name": "a11yCheck",
+        "type": "text",
+        "label": "Assistive technology description for \"Check\" button",
+        "default": "Check the answers. The responses will be marked as correct, incorrect, or unanswered."
+      },
+      {
+        "name": "a11yShowSolution",
+        "type": "text",
+        "label": "Assistive technology description for \"Show Solution\" button",
+        "default": "Show the solution. The task will be marked with its correct solution."
+      },
+      {
+        "name": "a11yRetry",
+        "type": "text",
+        "label": "Assistive technology description for \"Retry\" button",
+        "default": "Retry the task. Reset all responses and start the task over again."
+      },
+      {
+        "name": "a11yCheckingModeHeader",
+        "type": "text",
+        "label": "Assistive technology description for starting task",
+        "default": "Checking mode"
+      }
+    ]
+  },
+  {
+    "label": "Localization for DragText",
+    "name": "dragtextl10n",
+    "importance": "low",
+    "type": "group",
+    "common": true,
+    "fields": [
+      {
+        "label": "Text for \"Check\" button",
+        "name": "checkAnswer",
+        "type": "text",
+        "default": "Check"
+      },
+      {
+        "label": "Text for \"Submit\" button",
+        "name": "submitAnswer",
+        "type": "text",
+        "default": "Submit"
+      },
+      {
+        "label": "Text for \"Retry\" button",
+        "name": "tryAgain",
+        "type": "text",
+        "default": "Retry"
+      },
+      {
+        "label": "Text for \"Show Solution\" button",
+        "name": "showSolution",
+        "type": "text",
+        "default": "Show solution"
+      },
+      {
+        "label": "Numbered Drop zone label",
+        "name": "dropZoneIndex",
+        "type": "text",
+        "default": "Drop Zone @index.",
+        "description": "Label used for accessibility, where the Read speaker will read the index of a drop zone. Variable available: @index."
+      },
+      {
+        "label": "Empty Drop Zone label",
+        "name": "empty",
+        "type": "text",
+        "default": "Drop Zone @index is empty.",
+        "description": "Label used for accessibility, where the Read speaker will read that the drop zone is empty."
+      },
+      {
+        "label": "Contains Drop Zone label",
+        "name": "contains",
+        "type": "text",
+        "default": "Drop Zone @index contains draggable @draggable.",
+        "description": "Label used for accessibility, where the Read speaker will read that the drop zone contains a draggable."
+      },
+      {
+        "label": "Draggable elements label",
+        "name": "ariaDraggableIndex",
+        "type": "text",
+        "default": "@index of @count draggables.",
+        "description": "Label used for accessibility, where the Read speaker reads that this is a draggable element. Variable available: @index, @count."
+      },
+      {
+        "label": "Label for show tip button",
+        "name": "tipLabel",
+        "type": "text",
+        "default": "Show tip",
+        "description": "Label used for accessibility, where the Read speaker reads it before the tip is read out."
+      },
+      {
+        "name": "correctText",
+        "type": "text",
+        "label": "Readspeaker text for correct answer",
+        "default": "Correct!"
+      },
+      {
+        "name": "incorrectText",
+        "type": "text",
+        "label": "Readspeaker text for incorrect answer",
+        "default": "Incorrect!"
+      },
+      {
+        "name": "resetDropTitle",
+        "type": "text",
+        "label": "Confirmation dialog title that user wants to reset a droppable",
+        "default": "Reset drop"
+      },
+      {
+        "name": "resetDropDescription",
+        "type": "text",
+        "label": "Confirmation dialog description that user wants to reset a droppable",
+        "default": "Are you sure you want to reset this drop zone?"
+      },
+      {
+        "name": "grabbed",
+        "type": "text",
+        "label": "Label used for accessibility, where the read speaker indicates that dragging is initiated",
+        "default": "Draggable is grabbed."
+      },
+      {
+        "name": "cancelledDragging",
+        "type": "text",
+        "label": "Label used for accessibility, where the read speaker indicates that dragging is canceled",
+        "default": "Cancelled dragging."
+      },
+      {
+        "name": "correctAnswer",
+        "type": "text",
+        "label": "Label used for accessibility, where the read speaker indicates that a text is the correct answer",
+        "default": "Correct answer:"
+      },
+      {
+        "name": "feedbackHeader",
+        "type": "text",
+        "label": "Header for panel containing feedback for correct/incorrect answers",
+        "default": "Feedback"
+      },
+      {
+        "name": "scoreBarLabel",
+        "type": "text",
+        "label": "Textual representation of the score bar for those using a readspeaker",
+        "default": "You got :num out of :total points"
+      },
+      {
+        "name": "a11yCheck",
+        "type": "text",
+        "label": "Assistive technology label for \"Check\" button",
+        "default": "Check the answers. The responses will be marked as correct, incorrect, or unanswered."
+      },
+      {
+        "name": "a11yShowSolution",
+        "type": "text",
+        "label": "Assistive technology label for \"Show Solution\" button",
+        "default": "Show the solution. The task will be marked with its correct solution."
+      },
+      {
+        "name": "a11yRetry",
+        "type": "text",
+        "label": "Assistive technology label for \"Retry\" button",
+        "default": "Retry the task. Reset all responses and start the task over again."
+      }
+    ]
+  },
+  {
+    "name": "behaviour",
+    "type": "group",
+    "label": "Behavioural settings",
+    "importance": "low",
+    "description": "These options will let you control how the task behaves.",
+    "fields": [
+      {
+        "label": "Enable \"Retry\"",
+        "importance": "low",
+        "name": "enableRetry",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "label": "Enable \"Show solution\" button",
+        "importance": "low",
+        "name": "enableSolutionsButton",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "label": "Automatically check answers after input",
+        "importance": "low",
+        "name": "autoCheck",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "caseSensitive",
+        "importance": "low",
+        "type": "boolean",
+        "default": true,
+        "label": "Case sensitive",
+        "description": "Makes sure the user input has to be exactly the same as the answer."
+      },
+      {
+        "label": "Require all fields to be answered before the solution can be viewed",
+        "description": "This option is only valid if the answer mode is set to \"Fill in\".",
+        "importance": "low",
+        "name": "showSolutionsRequiresInput",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "acceptSpellingErrors",
+        "type": "boolean",
+        "label": "Accept minor spelling errors",
+        "importance": "low",
+        "description": "If activated, an answer will also count as correct with minor spelling errors (3-9 characters: 1 spelling error, more than 9 characters: 2 spelling errors). This option is only valid if the answer mode is set to \"Fill in\".",
+        "default": false
+      },
+      {
+        "label": "Randomize",
+        "name": "randomize",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "label": "Show tips",
+        "name": "showTips",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "label": "Answer mode",
+        "name": "answerMode",
+        "type": "select",
+        "widget": "radioGroup",
+        "alignment": "horizontal",
+        "options": [
+          { "label": "Fill in", "value": "fillIn" },
+          { "label": "Drag text", "value": "dragText" }
+        ],
+        "default": "fillIn"
+      },
+      {
+        "name": "enableSwitchAnswerModeButton",
+        "type": "boolean",
+        "label": "Enable \"Switch answer mode\" button",
+        "importance": "low",
+        "description": "Allow the end user to switch between modes \"Fill in\" and \"Drag text\".",
+        "default": false
+      },
+      {
+        "name": "enableSwitchWordsButton",
+        "type": "boolean",
+        "label": "Enable \"Switch language mode\" button",
+        "importance": "low",
+        "description": "Allow the end user to switch between source and target words.",
+        "default": false
+      },
+      {
+        "label": "Number of words",
+        "name": "numberOfWordsToShow",
+        "description": "Defines how many words will be visible each time. If 0 is set, all words will be shown.",
+        "type": "number",
+        "optional": true
+      }
+    ]
+  }
+]

--- a/examples/h5p-content-type-vite/semantics.json.d.ts
+++ b/examples/h5p-content-type-vite/semantics.json.d.ts
@@ -1,0 +1,618 @@
+declare const json: [
+  {
+    "label": "Task description",
+    "name": "description",
+    "description": "A guide telling the user how to answer this task.",
+    "type": "text",
+    "optional": true
+  },
+  {
+    "label": "Source language",
+    "name": "sourceLanguage",
+    "description": "Choose the language of the source words.",
+    "type": "select",
+    "options": [
+      { "value": "en", "label": "English" },
+      { "value": "fr", "label": "French" },
+      { "value": "de", "label": "German" },
+      { "value": "nb", "label": "Norwegian bokmål" },
+      { "value": "nn", "label": "Norwegian nynorsk" },
+      { "value": "es", "label": "Spanish" }
+    ],
+    "default": "en"
+  },
+  {
+    "label": "Target language",
+    "name": "targetLanguage",
+    "description": "Choose the language of the target words.",
+    "type": "select",
+    "options": [
+      { "value": "en", "label": "English" },
+      { "value": "fr", "label": "French" },
+      { "value": "de", "label": "German" },
+      { "value": "nb", "label": "Norwegian bokmål" },
+      { "value": "nn", "label": "Norwegian nynorsk" },
+      { "value": "es", "label": "Spanish" }
+    ],
+    "default": "nb"
+  },
+  {
+    "label": "Words",
+    "name": "words",
+    "type": "text",
+    "optional": true,
+    "widget": "csv-to-text",
+    "description": "Add words by uploading a CSV-file or write them in the text field.",
+    "important": {
+      "description": "<ul><li>Source and target words are separated with a comma (,).</li><li>Alternative answers are separated with a forward slash (/).</li><li>You may add a textual tip, using a colon (:) in front of the tip.</li></ul>",
+      "example": "water/sea:w___r,vann/hav:v__n"
+    }
+  },
+  {
+    "name": "overallFeedback",
+    "type": "group",
+    "label": "Overall Feedback",
+    "importance": "low",
+    "expanded": true,
+    "fields": [
+      {
+        "name": "overallFeedback",
+        "type": "list",
+        "widgets": [
+          {
+            "name": "RangeList",
+            "label": "Default"
+          }
+        ],
+        "importance": "high",
+        "label": "Define custom feedback for any score range",
+        "description": "Click the \"Add range\" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!",
+        "entity": "range",
+        "min": 1,
+        "defaultNum": 1,
+        "optional": true,
+        "field": {
+          "label": "Overall Feedback",
+          "name": "overallFeedback",
+          "type": "group",
+          "importance": "low",
+          "fields": [
+            {
+              "name": "from",
+              "type": "number",
+              "label": "Score Range",
+              "min": 0,
+              "max": 100,
+              "default": 0,
+              "unit": "%"
+            },
+            {
+              "name": "to",
+              "type": "number",
+              "min": 0,
+              "max": 100,
+              "default": 100,
+              "unit": "%"
+            },
+            {
+              "name": "feedback",
+              "type": "text",
+              "label": "Feedback for defined score range",
+              "importance": "low",
+              "placeholder": "Fill in the feedback",
+              "optional": true
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "label": "Localization",
+    "name": "l10n",
+    "type": "group",
+    "importance": "low",
+    "common": true,
+    "fields": [
+      {
+        "label": "No valid words",
+        "name": "noValidWords",
+        "default": "No valid words found. Please check your words and try again.",
+        "type": "text"
+      },
+      {
+        "label": "Label for \"Fill in\" answer mode",
+        "name": "fillInLabel",
+        "default": "Fill in",
+        "type": "text"
+      },
+      {
+        "label": "Label for \"Drag text\" answer mode",
+        "name": "dragTextLabel",
+        "default": "Drag text",
+        "type": "text"
+      },
+      {
+        "label": "Answer mode label",
+        "name": "answerModeLabel",
+        "default": "Change answer mode",
+        "type": "text"
+      },
+      {
+        "label": "Language mode label",
+        "name": "languageModeLabel",
+        "default": "Swap languages",
+        "type": "text"
+      },
+      {
+        "label": "Changed answer mode aria",
+        "name": "changedAnswerModeAria",
+        "default": "Changed answer mode to @option",
+        "type": "text"
+      },
+      {
+        "label": "Language mode aria",
+        "name": "languageModeAria",
+        "default": "Swap language from @sourceLanguage to @targetLanguage",
+        "type": "text"
+      },
+      {
+        "label": "Changed language mode aria",
+        "name": "changedLanguageModeAria",
+        "default": "Swapped language from @sourceLanguage to @targetLanguage",
+        "type": "text"
+      },
+      {
+        "label": "Text for \"Next\" button",
+        "name": "next",
+        "default": "Next",
+        "type": "text"
+      },
+      {
+        "label": "Text for \"Finish\" button",
+        "name": "finish",
+        "default": "Finish",
+        "type": "text"
+      },
+      {
+        "label": "Text for \"Restart\" button",
+        "name": "restart",
+        "default": "Restart",
+        "type": "text"
+      },
+      {
+        "label": "Score label",
+        "name": "scoreLabel",
+        "default": "Score",
+        "type": "text"
+      },
+      {
+        "label": "Textual representation of the score bar for those using a readspeaker",
+        "name": "scoreBarLabel",
+        "default": "You got @score out of @maxScore points",
+        "type": "text"
+      },
+      {
+        "label": "Textual representation of the page numbers for those using a readspeaker",
+        "name": "pageNumberLabel",
+        "default": "Page @page of @totalPages",
+        "type": "text"
+      },
+      {
+        "label": "Feedback text",
+        "name": "feedbackText",
+        "default": "Your total score",
+        "type": "text"
+      },
+      {
+        "label": "English",
+        "name": "lang_en",
+        "default": "English",
+        "type": "text"
+      },
+      {
+        "label": "French",
+        "name": "lang_fr",
+        "default": "French",
+        "type": "text"
+      },
+      {
+        "label": "German",
+        "name": "lang_de",
+        "default": "German",
+        "type": "text"
+      },
+      {
+        "label": "Norwegian bokmål",
+        "name": "lang_nb",
+        "default": "Norwegian bokmål",
+        "type": "text"
+      },
+      {
+        "label": "Norwegian nynorsk",
+        "name": "lang_nn",
+        "default": "Norwegian nynorsk",
+        "type": "text"
+      },
+      {
+        "label": "Spanish",
+        "name": "lang_es",
+        "default": "Spanish",
+        "type": "text"
+      }
+    ]
+  },
+  {
+    "label": "Localization for Blanks",
+    "name": "blanksl10n",
+    "importance": "low",
+    "type": "group",
+    "common": true,
+    "fields": [
+      {
+        "label": "Text for \"Show solutions\" button",
+        "name": "showSolutions",
+        "type": "text",
+        "default": "Show solution"
+      },
+      {
+        "label": "Text for \"Retry\" button",
+        "name": "tryAgain",
+        "type": "text",
+        "default": "Retry",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Check\" button",
+        "name": "checkAnswer",
+        "type": "text",
+        "default": "Check",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Submit\" button",
+        "name": "submitAnswer",
+        "type": "text",
+        "default": "Submit",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Not filled out\" message",
+        "name": "notFilledOut",
+        "type": "text",
+        "default": "Please fill in all blanks to view solution",
+        "optional": true
+      },
+      {
+        "label": "Text for \"':ans' is correct\" message",
+        "name": "answerIsCorrect",
+        "type": "text",
+        "default": "':ans' is correct",
+        "optional": true
+      },
+      {
+        "label": "Text for \"':ans' is wrong\" message",
+        "name": "answerIsWrong",
+        "type": "text",
+        "default": "':ans' is wrong",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Answered correctly\" message",
+        "name": "answeredCorrectly",
+        "type": "text",
+        "default": "Answered correctly",
+        "optional": true
+      },
+      {
+        "label": "Text for \"Answered incorrectly\" message",
+        "name": "answeredIncorrectly",
+        "type": "text",
+        "default": "Answered incorrectly",
+        "optional": true
+      },
+      {
+        "label": "Assistive technology label for solution",
+        "name": "solutionLabel",
+        "type": "text",
+        "default": "Correct answer:",
+        "optional": true
+      },
+      {
+        "label": "Assistive technology label for input field",
+        "name": "inputLabel",
+        "type": "text",
+        "description": "Use @num and @total to replace current cloze number and total cloze number.",
+        "default": "Blank input @num of @total",
+        "optional": true
+      },
+      {
+        "label": "Assistive technology label for saying an input has a tip tied to it",
+        "name": "inputHasTipLabel",
+        "type": "text",
+        "default": "Tip available",
+        "optional": true
+      },
+      {
+        "label": "Tip icon label",
+        "name": "tipLabel",
+        "type": "text",
+        "default": "Tip",
+        "optional": true
+      },
+      {
+        "name": "scoreBarLabel",
+        "type": "text",
+        "label": "Textual representation of the score bar for those using a readspeaker",
+        "default": "You got :num out of :total points"
+      },
+      {
+        "name": "a11yCheck",
+        "type": "text",
+        "label": "Assistive technology description for \"Check\" button",
+        "default": "Check the answers. The responses will be marked as correct, incorrect, or unanswered."
+      },
+      {
+        "name": "a11yShowSolution",
+        "type": "text",
+        "label": "Assistive technology description for \"Show Solution\" button",
+        "default": "Show the solution. The task will be marked with its correct solution."
+      },
+      {
+        "name": "a11yRetry",
+        "type": "text",
+        "label": "Assistive technology description for \"Retry\" button",
+        "default": "Retry the task. Reset all responses and start the task over again."
+      },
+      {
+        "name": "a11yCheckingModeHeader",
+        "type": "text",
+        "label": "Assistive technology description for starting task",
+        "default": "Checking mode"
+      }
+    ]
+  },
+  {
+    "label": "Localization for DragText",
+    "name": "dragtextl10n",
+    "importance": "low",
+    "type": "group",
+    "common": true,
+    "fields": [
+      {
+        "label": "Text for \"Check\" button",
+        "name": "checkAnswer",
+        "type": "text",
+        "default": "Check"
+      },
+      {
+        "label": "Text for \"Submit\" button",
+        "name": "submitAnswer",
+        "type": "text",
+        "default": "Submit"
+      },
+      {
+        "label": "Text for \"Retry\" button",
+        "name": "tryAgain",
+        "type": "text",
+        "default": "Retry"
+      },
+      {
+        "label": "Text for \"Show Solution\" button",
+        "name": "showSolution",
+        "type": "text",
+        "default": "Show solution"
+      },
+      {
+        "label": "Numbered Drop zone label",
+        "name": "dropZoneIndex",
+        "type": "text",
+        "default": "Drop Zone @index.",
+        "description": "Label used for accessibility, where the Read speaker will read the index of a drop zone. Variable available: @index."
+      },
+      {
+        "label": "Empty Drop Zone label",
+        "name": "empty",
+        "type": "text",
+        "default": "Drop Zone @index is empty.",
+        "description": "Label used for accessibility, where the Read speaker will read that the drop zone is empty."
+      },
+      {
+        "label": "Contains Drop Zone label",
+        "name": "contains",
+        "type": "text",
+        "default": "Drop Zone @index contains draggable @draggable.",
+        "description": "Label used for accessibility, where the Read speaker will read that the drop zone contains a draggable."
+      },
+      {
+        "label": "Draggable elements label",
+        "name": "ariaDraggableIndex",
+        "type": "text",
+        "default": "@index of @count draggables.",
+        "description": "Label used for accessibility, where the Read speaker reads that this is a draggable element. Variable available: @index, @count."
+      },
+      {
+        "label": "Label for show tip button",
+        "name": "tipLabel",
+        "type": "text",
+        "default": "Show tip",
+        "description": "Label used for accessibility, where the Read speaker reads it before the tip is read out."
+      },
+      {
+        "name": "correctText",
+        "type": "text",
+        "label": "Readspeaker text for correct answer",
+        "default": "Correct!"
+      },
+      {
+        "name": "incorrectText",
+        "type": "text",
+        "label": "Readspeaker text for incorrect answer",
+        "default": "Incorrect!"
+      },
+      {
+        "name": "resetDropTitle",
+        "type": "text",
+        "label": "Confirmation dialog title that user wants to reset a droppable",
+        "default": "Reset drop"
+      },
+      {
+        "name": "resetDropDescription",
+        "type": "text",
+        "label": "Confirmation dialog description that user wants to reset a droppable",
+        "default": "Are you sure you want to reset this drop zone?"
+      },
+      {
+        "name": "grabbed",
+        "type": "text",
+        "label": "Label used for accessibility, where the read speaker indicates that dragging is initiated",
+        "default": "Draggable is grabbed."
+      },
+      {
+        "name": "cancelledDragging",
+        "type": "text",
+        "label": "Label used for accessibility, where the read speaker indicates that dragging is canceled",
+        "default": "Cancelled dragging."
+      },
+      {
+        "name": "correctAnswer",
+        "type": "text",
+        "label": "Label used for accessibility, where the read speaker indicates that a text is the correct answer",
+        "default": "Correct answer:"
+      },
+      {
+        "name": "feedbackHeader",
+        "type": "text",
+        "label": "Header for panel containing feedback for correct/incorrect answers",
+        "default": "Feedback"
+      },
+      {
+        "name": "scoreBarLabel",
+        "type": "text",
+        "label": "Textual representation of the score bar for those using a readspeaker",
+        "default": "You got :num out of :total points"
+      },
+      {
+        "name": "a11yCheck",
+        "type": "text",
+        "label": "Assistive technology label for \"Check\" button",
+        "default": "Check the answers. The responses will be marked as correct, incorrect, or unanswered."
+      },
+      {
+        "name": "a11yShowSolution",
+        "type": "text",
+        "label": "Assistive technology label for \"Show Solution\" button",
+        "default": "Show the solution. The task will be marked with its correct solution."
+      },
+      {
+        "name": "a11yRetry",
+        "type": "text",
+        "label": "Assistive technology label for \"Retry\" button",
+        "default": "Retry the task. Reset all responses and start the task over again."
+      }
+    ]
+  },
+  {
+    "name": "behaviour",
+    "type": "group",
+    "label": "Behavioural settings",
+    "importance": "low",
+    "description": "These options will let you control how the task behaves.",
+    "fields": [
+      {
+        "label": "Enable \"Retry\"",
+        "importance": "low",
+        "name": "enableRetry",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "label": "Enable \"Show solution\" button",
+        "importance": "low",
+        "name": "enableSolutionsButton",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "label": "Automatically check answers after input",
+        "importance": "low",
+        "name": "autoCheck",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "name": "caseSensitive",
+        "importance": "low",
+        "type": "boolean",
+        "default": true,
+        "label": "Case sensitive",
+        "description": "Makes sure the user input has to be exactly the same as the answer."
+      },
+      {
+        "label": "Require all fields to be answered before the solution can be viewed",
+        "description": "This option is only valid if the answer mode is set to \"Fill in\".",
+        "importance": "low",
+        "name": "showSolutionsRequiresInput",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "name": "acceptSpellingErrors",
+        "type": "boolean",
+        "label": "Accept minor spelling errors",
+        "importance": "low",
+        "description": "If activated, an answer will also count as correct with minor spelling errors (3-9 characters: 1 spelling error, more than 9 characters: 2 spelling errors). This option is only valid if the answer mode is set to \"Fill in\".",
+        "default": false
+      },
+      {
+        "label": "Randomize",
+        "name": "randomize",
+        "type": "boolean",
+        "default": true
+      },
+      {
+        "label": "Show tips",
+        "name": "showTips",
+        "type": "boolean",
+        "default": false
+      },
+      {
+        "label": "Answer mode",
+        "name": "answerMode",
+        "type": "select",
+        "widget": "radioGroup",
+        "alignment": "horizontal",
+        "options": [
+          { "label": "Fill in", "value": "fillIn" },
+          { "label": "Drag text", "value": "dragText" }
+        ],
+        "default": "fillIn"
+      },
+      {
+        "name": "enableSwitchAnswerModeButton",
+        "type": "boolean",
+        "label": "Enable \"Switch answer mode\" button",
+        "importance": "low",
+        "description": "Allow the end user to switch between modes \"Fill in\" and \"Drag text\".",
+        "default": false
+      },
+      {
+        "name": "enableSwitchWordsButton",
+        "type": "boolean",
+        "label": "Enable \"Switch language mode\" button",
+        "importance": "low",
+        "description": "Allow the end user to switch between source and target words.",
+        "default": false
+      },
+      {
+        "label": "Number of words",
+        "name": "numberOfWordsToShow",
+        "description": "Defines how many words will be visible each time. If 0 is set, all words will be shown.",
+        "type": "number",
+        "optional": true
+      }
+    ]
+  }
+]
+
+export default json;

--- a/examples/h5p-content-type-vite/src/h5p-content-type-vite.ts
+++ b/examples/h5p-content-type-vite/src/h5p-content-type-vite.ts
@@ -1,0 +1,23 @@
+import type { IH5PContentType, InferParamsFromSemantics } from "h5p-types";
+import { H5P, H5PContentType, registerContentType } from "h5p-utils";
+import library from "../library.json";
+import semantics from "../semantics.json";
+
+type Params = InferParamsFromSemantics<typeof semantics>;
+
+class ContentType
+  extends H5PContentType<Params>
+  implements IH5PContentType<Params>
+{
+  attach($wrapper: JQuery<HTMLElement>): void {
+    // `h5p-extensions.d.ts` extends `h5p-types-joubel-ui` which includes `H5P.JoubelUI`
+    const button = H5P.JoubelUI.createButton({
+      title: this.params.l10n.finish,
+    });
+
+    $wrapper.append(button);
+  }
+}
+
+const contentTypeName = library.machineName.replace("H5P.", "");
+registerContentType(contentTypeName, ContentType);

--- a/examples/h5p-content-type-vite/tsconfig.json
+++ b/examples/h5p-content-type-vite/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "include": ["src", "h5p-extensions.d.ts"],
+  "extends": "tsconfig-base/index.json"
+}

--- a/examples/h5p-content-type-vite/vite.config.ts
+++ b/examples/h5p-content-type-vite/vite.config.ts
@@ -1,0 +1,32 @@
+import jsonDts from "unplugin-json-dts/vite";
+import { defineConfig } from "vite";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    minify: "esbuild",
+
+    lib: {
+      entry: ["src/h5p-content-type-vite.ts"],
+      formats: ["iife"],
+      name: "H5PContentTypeVite",
+      fileName: () => "h5p-content-type-vite.js",
+    },
+
+    rollupOptions: {
+      output: {
+        assetFileNames: assetInfo => {
+          // For some reason, an H5P content type's style file cannot be named `style.css`.
+          // Therefore we need to change the name before saving it.
+          if (assetInfo.name === "style.css") {
+            return "h5p-content-type-vite.css";
+          }
+
+          return assetInfo.name ?? "";
+        },
+      },
+    },
+  },
+
+  plugins: [jsonDts()],
+});

--- a/examples/h5p-content-type/README.md
+++ b/examples/h5p-content-type/README.md
@@ -1,0 +1,7 @@
+# H5P Content Type with webpack
+
+This is a boilerplate for creating H5P content types with [webpack](https://webpack.js.org/).
+The code itself is very simplistic and only serves as a starting point for your own content type.
+The project uses webpack as build tool.
+This is the most common way of building H5P content types.
+If you want to opt for something that is quicker to build, you can check out the [Vite template](../h5p-content-type-vite/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,34 @@
         "node": ">=14.17"
       }
     },
+    "examples/h5p-content-type-vite": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "h5p-utils": "*"
+      },
+      "devDependencies": {
+        "eslint-config-base": "*",
+        "h5p-types": "*",
+        "h5p-types-joubel-ui": "*",
+        "tsconfig-base": "*",
+        "typescript": "5.0",
+        "unplugin-json-dts": "^1.2.0"
+      }
+    },
+    "examples/h5p-content-type-vite/node_modules/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "examples/h5p-content-type/node_modules/typescript": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
@@ -10312,6 +10340,10 @@
     },
     "node_modules/h5p-content-type-react": {
       "resolved": "examples/h5p-content-type-react",
+      "link": true
+    },
+    "node_modules/h5p-content-type-vite": {
+      "resolved": "examples/h5p-content-type-vite",
       "link": true
     },
     "node_modules/h5p-generate-configs": {


### PR DESCRIPTION
## 📝 Description

<!--
Please provide a brief description of the purpose and context of this
pull request. What problem does it address or what feature does it
introduce? This will help reviewers understand the changes at a high
level. Include any relevant background information or references to
issues/feature requests.
-->

This PR adds a new examples which is a clone of the previous `H5P Content Type` example, but where webpack is switched out for Vite.