### PR TITLE
feat: make optional fields truly optional

### DIFF
--- a/packages/h5p-types/src/types/InferParamTypeFromFieldType.ts
+++ b/packages/h5p-types/src/types/InferParamTypeFromFieldType.ts
@@ -34,7 +34,9 @@ type H5PFieldSelectWithoutLabel = Omit<H5PFieldSelect, "label">;
 type H5PFieldTextWithoutLabel = Omit<H5PFieldText, "label">;
 type H5PFieldVideoWithoutLabel = Omit<H5PFieldVideo, "label">;
 
-export type FieldToParamType<TField extends ReadonlyDeep<H5PFieldWithoutLabel>> =
+export type FieldToParamType<
+  TField extends ReadonlyDeep<H5PFieldWithoutLabel>,
+> =
   TField extends ReadonlyDeep<H5PFieldAudioWithoutLabel>
     ? H5PAudio
     : TField extends ReadonlyDeep<H5PFieldBooleanWithoutLabel>

--- a/packages/h5p-types/src/types/InferParamTypeFromFieldType.ts
+++ b/packages/h5p-types/src/types/InferParamTypeFromFieldType.ts
@@ -34,7 +34,7 @@ type H5PFieldSelectWithoutLabel = Omit<H5PFieldSelect, "label">;
 type H5PFieldTextWithoutLabel = Omit<H5PFieldText, "label">;
 type H5PFieldVideoWithoutLabel = Omit<H5PFieldVideo, "label">;
 
-type FieldToParamType<TField extends ReadonlyDeep<H5PFieldWithoutLabel>> =
+export type FieldToParamType<TField extends ReadonlyDeep<H5PFieldWithoutLabel>> =
   TField extends ReadonlyDeep<H5PFieldAudioWithoutLabel>
     ? H5PAudio
     : TField extends ReadonlyDeep<H5PFieldBooleanWithoutLabel>

--- a/packages/h5p-types/src/types/InferParamsFromSemantics.ts
+++ b/packages/h5p-types/src/types/InferParamsFromSemantics.ts
@@ -1,7 +1,10 @@
 import type { ReadonlyDeep } from "type-fest";
 import type { H5PField } from "./H5PField";
 import type { InferL10nType, L10nGroupWithoutLabel } from "./InferL10nType";
-import type { InferOptionalWithDefault } from "./InferParamTypeFromFieldType";
+import type {
+  FieldToParamType,
+  InferOptionalWithDefault,
+} from "./InferParamTypeFromFieldType";
 
 type H5PFieldWithoutLabel = Omit<H5PField, "label">;
 
@@ -84,6 +87,11 @@ export type InferParamsFromSemantics<
 ]
   ? (TField extends ReadonlyDeep<L10nGroupWithoutLabel>
       ? InferL10nType<TField>
-      : Record<TField["name"], InferOptionalWithDefault<TField>>) &
+      : TField extends { optional: true }
+        ? TField extends { default: FieldToParamType<TField> }
+          ? Record<TField["name"], InferOptionalWithDefault<TField>>
+          : // If the field is optional but does not have a default value, we infer it as `FieldToParamType<TField> | undefined`
+            Partial<Record<TField["name"], InferOptionalWithDefault<TField>>>
+        : Record<TField["name"], InferOptionalWithDefault<TField>>) &
       InferParamsFromSemantics<TRestFields>
   : unknown;

--- a/packages/h5p-types/test/InferGroupParams.test.ts
+++ b/packages/h5p-types/test/InferGroupParams.test.ts
@@ -177,7 +177,7 @@ namespace Test_OverallFeedback {
     | {
         from: number;
         to: number;
-        feedback: string | undefined;
+        feedback?: string | undefined;
       }[]
     | undefined;
 

--- a/packages/h5p-types/test/InferParamTypeFromFieldType.test.ts
+++ b/packages/h5p-types/test/InferParamTypeFromFieldType.test.ts
@@ -193,7 +193,7 @@ namespace Test_ListField_Group {
 
   type Expected = Array<{
     name: string;
-    age: number | undefined;
+    age?: number | undefined;
   }>;
 
   type Actual = InferParamTypeFromFieldType<FieldType>;
@@ -235,7 +235,7 @@ namespace Test_ListField_Group {
 
   type Expected = Array<{
     name: string;
-    age: number | undefined;
+    age?: number | undefined;
   }>;
   type Actual = InferParamTypeFromFieldType<FieldType>;
 
@@ -272,7 +272,7 @@ namespace Test_ListField_Group_NoLabel {
 
   type Expected = Array<{
     name: string;
-    age: number | undefined;
+    age?: number | undefined;
   }>;
   type Actual = InferParamTypeFromFieldType<FieldType>;
 

--- a/packages/h5p-types/test/InferParamsFromSemantics.test.ts
+++ b/packages/h5p-types/test/InferParamsFromSemantics.test.ts
@@ -255,14 +255,14 @@ namespace Test_OptionalFields {
 
   type Expected = {
     group: {
-      field1: number | undefined;
-      field2:
+      field1?: number | undefined;
+      field2?:
         | {
             field1: number;
             field2: string;
           }
         | undefined;
-      field3: number | undefined;
+      field3?: number | undefined;
       field4: number | undefined;
       field5: number;
       field6: number;
@@ -1077,14 +1077,14 @@ namespace Test_VocabularyDrill {
   ];
 
   type Expected = {
-    description: string | undefined;
+    description?: string | undefined;
     sourceLanguage: "de" | "en" | "fr" | "nb" | "nn" | "es";
     targetLanguage: "de" | "en" | "fr" | "nb" | "nn" | "es";
-    words: string | undefined;
+    words?: string | undefined;
     overallFeedback: Array<{
       from: number;
       to: number;
-      feedback: string | undefined;
+      feedback?: string | undefined;
     }>;
     l10n: EmptyObject;
     behaviour: {


### PR DESCRIPTION
## 📝 Description

<!--
Please provide a brief description of the purpose and context of this
pull request. What problem does it address or what feature does it
introduce? This will help reviewers understand the changes at a high
level. Include any relevant background information or references to
issues/feature requests.
-->

Optional fields previously were marked as `T | undefined`, but are now also marked as optional.

Considering the following semantics.json input:

```json
[
  {
    "name": "name",
    "type": "text"
  },
  {
    "name": "country",
    "type": "text",
    "optional": true
  }
]
```

We previously inferred:

```ts
type Semantics = {
  name: string;
  country: string | undefined;
};
```

This will now become:

```ts
type Semantics = {
  name: string;
  country?: string | undefined;
};
```
