### PR TITLE
fix(h5p-types): Fix inferring of group with only one child field which is optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8443,10 +8443,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -11969,7 +11971,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -13404,11 +13408,26 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "dev": true
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/is-arguments": {
       "version": "1.1.1",
@@ -13748,6 +13767,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -15330,6 +15351,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -24651,15 +24679,17 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -25609,6 +25639,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/packages/h5p-types/test/InferGroupParams.test.ts
+++ b/packages/h5p-types/test/InferGroupParams.test.ts
@@ -188,3 +188,91 @@ namespace Test_OverallFeedback {
     // prettier-ignore
     Expect<AreEqual<Actual, Expected>>;
 }
+
+// @ts-ignore Test
+namespace Test_OverallFeedback_Wrapper {
+  const group = {
+    name: "overallFeedback",
+    type: "group",
+    label: "Overall Feedback",
+    importance: "low",
+    expanded: true,
+    fields: [
+      {
+        name: "overallFeedback",
+        type: "list",
+        widgets: [
+          {
+            name: "RangeList",
+            label: "Default",
+          },
+        ],
+        importance: "high",
+        label: "Define custom feedback for any score range",
+        description:
+          'Click the "Add range" button to add as many ranges as you need. Example: 0-20% Bad score, 21-91% Average Score, 91-100% Great Score!',
+        entity: "range",
+        min: 1,
+
+        optional: true,
+        field: {
+          label: "Overall Feedback",
+          name: "overallFeedback",
+          type: "group",
+          importance: "low",
+          fields: [
+            {
+              name: "from",
+              type: "number",
+              label: "Score Range",
+              min: 0,
+              max: 100,
+              default: 0,
+            },
+            {
+              name: "to",
+              type: "number",
+              min: 0,
+              max: 100,
+              default: 100,
+            },
+            {
+              name: "feedback",
+              type: "text",
+              label: "Feedback for defined score range",
+              importance: "low",
+              placeholder: "Fill in the feedback",
+              optional: true,
+            },
+          ],
+        },
+      },
+    ],
+  } as const satisfies ReadonlyDeep<H5PFieldGroup>;
+
+  const wrapperGroup = {
+    name: "wrapper",
+    type: "group",
+    fields: [group, { name: "text", type: "text" }],
+  } as const satisfies ReadonlyDeep<H5PFieldGroup>;
+
+  type Expected = {
+    // If the group (in this case overallFeedback) has only one field,
+    // then that group should inherit all properties from that field
+    // including `optional`.
+    overallFeedback?: {
+      from: number;
+      to: number;
+      feedback?: string | undefined;
+    }[];
+
+    text: string;
+  };
+
+  type Actual = InferGroupParams<typeof wrapperGroup>;
+
+  // @ts-ignore Test
+  type Test =
+    // prettier-ignore
+    Expect<AreEqual<Actual, Expected>>;
+}

--- a/packages/h5p-types/test/InferParamsFromSemantics.test.ts
+++ b/packages/h5p-types/test/InferParamsFromSemantics.test.ts
@@ -263,7 +263,7 @@ namespace Test_OptionalFields {
           }
         | undefined;
       field3?: number | undefined;
-      field4: number | undefined;
+      field4?: number | undefined;
       field5: number;
       field6: number;
     };


### PR DESCRIPTION
## 📝 Description

<!--
Please provide a brief description of the purpose and context of this
pull request. What problem does it address or what feature does it
introduce? This will help reviewers understand the changes at a high
level. Include any relevant background information or references to
issues/feature requests.
-->

In the case where a group has only one field, we need to check both the group and its child field if they're optional. This PR extends the optional check to also look within the group.
