### PR TITLE
build: update turbo to v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "devDependencies": {
         "@biomejs/biome": "1.5.3",
-        "turbo": "^1.13.3"
+        "turbo": "^2.0.4"
       }
     },
     "examples/h5p-content-type": {
@@ -23355,102 +23355,102 @@
       }
     },
     "node_modules/turbo": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.4.tgz",
-      "integrity": "sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.0.4.tgz",
+      "integrity": "sha512-Ilme/2Q5kYw0AeRr+aw3s02+WrEYaY7U8vPnqSZU/jaDG/qd6jHVN6nRWyd/9KXvJGYM69vE6JImoGoyNjLwaw==",
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.13.4",
-        "turbo-darwin-arm64": "1.13.4",
-        "turbo-linux-64": "1.13.4",
-        "turbo-linux-arm64": "1.13.4",
-        "turbo-windows-64": "1.13.4",
-        "turbo-windows-arm64": "1.13.4"
+        "turbo-darwin-64": "2.0.4",
+        "turbo-darwin-arm64": "2.0.4",
+        "turbo-linux-64": "2.0.4",
+        "turbo-linux-arm64": "2.0.4",
+        "turbo-windows-64": "2.0.4",
+        "turbo-windows-arm64": "2.0.4"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.4.tgz",
-      "integrity": "sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.0.4.tgz",
+      "integrity": "sha512-x9mvmh4wudBstML8Z8IOmokLWglIhSfhQwnh2gBCSqabgVBKYvzl8Y+i+UCNPxheCGTgtsPepTcIaKBIyFIcvw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.4.tgz",
-      "integrity": "sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.4.tgz",
+      "integrity": "sha512-/B1Ih8zPRGVw5vw4SlclOf3C/woJ/2T6ieH6u54KT4wypoaVyaiyMqBcziIXycdObIYr7jQ+raHO7q3mhay9/A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.4.tgz",
-      "integrity": "sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.0.4.tgz",
+      "integrity": "sha512-6aG670e5zOWu6RczEYcB81nEl8EhiGJEvWhUrnAfNEUIMBEH1pR5SsMmG2ol5/m3PgiRM12r13dSqTxCLcHrVg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.4.tgz",
-      "integrity": "sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.0.4.tgz",
+      "integrity": "sha512-AXfVOjst+mCtPDFT4tCu08Qrfv12Nj7NDd33AjGwV79NYN1Y1rcFY59UQ4nO3ij3rbcvV71Xc+TZJ4csEvRCSg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.4.tgz",
-      "integrity": "sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.0.4.tgz",
+      "integrity": "sha512-QOnUR9hKl0T5gq5h1fAhVEqBSjpcBi/BbaO71YGQNgsr6pAnCQdbG8/r3MYXet53efM0KTdOhieWeO3KLNKybA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.4.tgz",
-      "integrity": "sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.0.4.tgz",
+      "integrity": "sha512-3v8WpdZy1AxZw0gha0q3caZmm+0gveBQ40OspD6mxDBIS+oBtO5CkxhIXkFJJW+jDKmDlM7wXDIGfMEq+QyNCQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.5.3",
-    "turbo": "^1.13.3"
-  }
+    "turbo": "^2.0.4"
+  },
+  "packageManager": "npm@10.8.1"
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**/*"]


### PR DESCRIPTION
## 📝 Description

<!--
Please provide a brief description of the purpose and context of this
pull request. What problem does it address or what feature does it
introduce? This will help reviewers understand the changes at a high
level. Include any relevant background information or references to
issues/feature requests.
-->

Uses `npx @turbo/codemod migrate` (from https://turbo.build/blog/turbo-2-0) to migrate Turborepo from v1 to v2.